### PR TITLE
Clearing 2024's FT and Subj Teachers details from website

### DIFF
--- a/_about-us/Our People/Primary 1 Teachers.md
+++ b/_about-us/Our People/Primary 1 Teachers.md
@@ -25,51 +25,5 @@ variant: markdown
 
 | Subject | Teacher |
 |---|---|
-| Art | Mr Fong Yan Kin<br>65080-661<br>[fong_yan_kin@schools.gov.sg](mailto:fong_yan_kin@schools.gov.sg) |
-| Art |Mrs Chew Yi Xin<br>65080-662<br>[tan\_yixin@schools.gov.sg](mailto:tan\_yixin@schools.gov.sg) |
-| Art |Mdm Karmila<br>65089-458<br>[nor\_karmila\_hamzah@schools.gov.sg](mailto:nor\_karmila\_hamzah@schools.gov.sg) |
-|
-| English Language |  Mrs Gracelyn Tham <br>65067-648<br>[lim\_ai\_zhen\_gracelyn@schools.gov.sg](mailto:lim\_ai\_zhen\_gracelyn@schools.gov.sg) |
-| English Language |  Ms Rachel Loh<br>65067-640<br>[loh\_hui\_xian\_rachel@schools.gov.sg](mailto:loh\_hui\_xian\_rachel@schools.gov.sg) |
-| English Language | Mdm Fatin<br>65067-649<br>[nur\_ishmah\_fatin\_rahim@schools.gov.sg](mailto:nur\_ishmah\_fatin\_rahim@schools.gov.sg) |
-| English Language | Mr Dallon Kang<br>65083-173<br>[kang\_zhenlin\_dallon@moe.edu.sg](mailto:kang\_zhenlin\_dallon@moe.edu.sg) |
-| English Language | Mrs Tan Lirong<br>65080-669<br>[sun\_lirong@schools.gov.sg](mailto:sun\_lirong@schools.gov.sg) |
-| English Language | Ms Vanna Ong<br>65067-642<br>[vanna\_ong\_limei@schools.gov.sg](mailto:vanna\_ong\_limei@schools.gov.sg) |
-| English Language |Mdm Annie Koh<br>65067-649<br>[yong\_puay\_hong\_annie@moe.edu.sg](mailto:yong\_puay\_hong\_annie@moe.edu.sg) |
-| English Language | Mdm Joey Cheang (SH, CCE)<br>65080-658<br>[cheang\_ching\_ee@schools.gov.sg](mailto:cheang\_ching\_ee@schools.gov.sg)  |
-| English Language | Mdm Munirah<br>65080-656<br>[siti\_nurmunirah\_mohd\_arsad@schools.gov.sg](mailto:siti\_nurmunirah\_mohd\_arsad@schools.gov.sg)  |
- English Language | Mdm Liza<br>65067-347<br>[siti\_nur\_haliza@schools.gov.sg](mailto:siti\_nur\_haliza@schools.gov.sg)
-| English Language | Mdm Suritha<br>65083-178<br>[suritha\_banu@moe.edu.sg](mailto:suritha\_banu@moe.edu.sg) |
-| 
-| Mathematics | Mdm Hailwa<br>65067-641<br>[hailwa\_moree@schools.gov.sg](mailto:hailwa\_moree@schools.gov.sg) |
-Mathematics |Mdm Fatin<br>65067-649<br>[nur\_ishmah\_fatin\_rahim@schools.gov.sg](mailto:nur\_ishmah\_fatin\_rahim@schools.gov.sg) |
-Mathematics | Ms Vanna Ong<br>65067-642<br>[vanna\_ong\_limei@schools.gov.sg](mailto:vanna\_ong\_limei@schools.gov.sg) |
-Mathematics | Mdm Joey Cheang (SH, CCE)<br>65080-658<br>[cheang\_ching\_ee@schools.gov.sg](mailto:cheang\_ching\_ee@schools.gov.sg) |
-Mathematics | Mdm Radiah<br>65067-341<br>[radiah\_rahmat@schools.gov.sg](mailto:radiah\_rahmat@schools.gov.sg) |
-Mathematics | Ms Seirrah Lim<br>65087-300 (Ext 285)<br>[lim\_mei\_fen@moe.edu.sg](mailto:lim\_mei\_fen@moe.edu.sg) |
-Mathematics | Mrs Jaslin Kwa<br>65089-455<br>[jaslin\_ku\_siew\_chen@moe.edu.sg](mailto:jaslin\_ku\_siew\_chen@moe.edu.sg) |
-Mathematics | Mdm Annie Koh<br>65067-649<br>[yong\_puay\_hong\_annie@moe.edu.sg](mailto:yong\_puay\_hong\_annie@moe.edu.sg)
-Mathematics |  Mdm Suritha<br>65083-178<br>[suritha\_banu@moe.edu.sg](mailto:suritha\_banu@moe.edu.sg) |
-Mathematics |Mrs Daphne Pereira<br>65089-466<br>[daphne\_saro\_pereira\_a@moe.edu.sg](mailto:daphne\_saro\_pereira\_a@moe.edu.sg)|
-|
-| Chinese Language  | Mdm Teo Siow Yee (ST, SEN)<br>65087-270<br>[teo\_siow\_yee@schools.gov.sg](mailto:teo\_siow\_yee@schools.gov.sg) |
-Chinese Language  |Mrs Lim Bee Li<br>65087-266<br>[tay\_bee\_li@schools.gov.sg](mailto:tay\_bee\_li@schools.gov.sg) |
-Chinese Language  | Ms Cher Xin Joo<br>65087-260<br>[cher\_xin\_joo@schools.gov.sg](mailto:cher\_xin\_joo@schools.gov.sg) |
-Chinese Language  | Mdm Jane Mah<br>65087-267<br>[mah\_zhiwei\_jane@schools.gov.sg](mailto:mah\_zhiwei\_jane@schools.gov.sg)  |
-Chinese Language  | Miss Germaine Quek<br>65087-272<br>[germaine\_quek\_jiamin@schools.gov.sg](mailto:germaine\_quek\_jiamin@schools.gov.sg) |
-Chinese Language  | Mrs Faye Loh (LH,CL)<br>65087-264<br>[quah\_pei\_jun@schools.gov.sg](mailto:quah\_pei\_jun@schools.gov.sg) |
-Chinese Language  | Mdm Zhang Yue<br>65087-262<br>[zhang\_yue\_a@schools.gov.sg](mailto:zhang\_yue\_a@schools.gov.sg) |
-|
-| Malay Language | Mdm Masturah  (SH, ML)<br>65087-317<br>[masturah\_salleh@schools.gov.sg](mailto:masturah\_salleh@schools.gov.sg) |
-Malay Language | Mdm Nabilah<br>65087-319 <br>[nabilah\_abdul\_rahman@schools.gov.sg](mailto:nabilah\_abdul\_rahman@schools.gov.sg)
-|
-| Tamil Language |Ms Sumitha<br>65087-315<br>[s\_sumitha@schools.gov.sg](mailto:s\_sumitha@schools.gov.sg) |
-|
-| Music | Ms Rebecca Lau (ST, Music)<br>65089-456<br>[rebecca\_lau\_yuen\_sun@schools.gov.sg](mailto:rebecca\_lau\_yuen\_sun@schools.gov.sg) |
-Music |Mrs Clara Koh (SH, Aesthetics)<br>65089-455<br>[lim\_xiu\_fang\_clara@schools.gov.sg](mailto:lim\_xiu\_fang\_clara@schools.gov.sg) 
-|
-| Physical Education &amp; Health Education | Mrs Michelle Khoo (SH, PE &amp; CCA)<br>65087-278<br>[lee\_jing\_wen\_michelle@schools.gov.sg](mailto:lee\_jing\_wen\_michelle@schools.gov.sg) |
-Physical Education &amp; Health Education | Mrs Valerie Koh<br>65087-279<br>[valerie\_koh\_sock\_hwee@schools.gov.sg](mailto:valerie\_koh\_sock\_hwee@schools.gov.sg)
-Physical Education &amp; Health Education | Ms Nazurah<br>65087-275<br>[nazurah\_syazana\_nordin@schools.gov.sg](mailto:nazurah\_syazana\_nordin@schools.gov.sg)
-Physical Education &amp; Health Education |Mr Noel Chan<br>65089-459 <br>[noel\_chan\_tze\_sunn@schools.gov.sg](mailto:noel\_chan\_tze\_sunn@schools.gov.sg)
-|
+
+To be updated soon.....

--- a/_about-us/Our People/Primary 1 Teachers.md
+++ b/_about-us/Our People/Primary 1 Teachers.md
@@ -11,14 +11,14 @@ variant: markdown
 
 | Class | Form Teacher | Form Teacher |
 |---|---|---|
-| 1 Aristotle | Ms Rachel Loh <br>65067-640<br>[loh\_hui\_xian\_rachel@schools.gov.sg](mailto:loh\_hui\_xian\_rachel@schools.gov.sg) | Mrs Valerie Koh<br>65087-279<br>[valerie\_koh\_sock\_hwee@schools.gov.sg](mailto:valerie\_koh\_sock\_hwee@schools.gov.sg) |
-| 1 Beethoven | Mdm Jane Mah<br>65087-267<br>[mah\_zhiwei\_jane@schools.gov.sg](mailto:mah\_zhiwei\_jane@schools.gov.sg) | Mrs Gracelyn Tham<br>65067-648<br>[lim\_ai\_zhen\_gracelyn@schools.gov.sg](mailto:lim\_ai\_zhen\_gracelyn@schools.gov.sg) |
-| 1 Curie | Mdm Fatin<br>65067-649<br>[nur\_ishmah\_fatin\_rahim@schools.gov.sg](mailto:nur\_ishmah\_fatin\_rahim@schools.gov.sg) | Mrs Faye Loh (LH, CL)<br>65087-264<br>[quah\_pei\_jun@schools.gov.sg](mailto:quah\_pei\_jun@schools.gov.sg) |
-| 1 Da Vinci | Mrs Tan Lirong<br>65080-669<br>[sun\_lirong@schools.gov.sg](mailto:sun\_lirong@schools.gov.sg) | Mdm Masturah  (SH, Malay Language)<br>65087-317<br>[masturah\_salleh@schools.gov.sg](mailto:masturah\_salleh@schools.gov.sg) |
-| 1 Edison | Ms Vanna Ong<br>65067-642<br>[vanna\_ong\_limei@schools.gov.sg](mailto:vanna\_ong\_limei@schools.gov.sg) | Mdm Teo Siow Yee  (ST, SEN)<br>65087-270<br>[teo\_siow\_yee@schools.gov.sg](mailto:teo\_siow\_yee@schools.gov.sg) |
-| 1 Frank |Mrs Lim Bee Li<br>65087-266<br>[tay\_bee\_li@schools.gov.sg](mailto:tay\_bee\_li@schools.gov.sg) | - | 
-| 1 Galileo | Mdm Radiah<br>65067-341<br>[radiah\_rahmat@schools.gov.sg](mailto:radiah\_rahmat@schools.gov.sg) | Mrs Michelle Khoo (SH, PE &amp; CCA)<br>65087-278<br>[lee\_jing\_wen\_michelle@schools.gov.sg](mailto:lee\_jing\_wen\_michelle@schools.gov.sg) |
-| 1 Hillary |Mdm Joey Cheang (SH, CCE)<br>65080-658<br>[cheang\_ching\_ee@schools.gov.sg](mailto:cheang\_ching\_ee@schools.gov.sg) | Mr Fong Yan Kin<br>65080-661<br>[fong\_yan\_kin@schools.gov.sg](mailto:fong\_yan\_kin@schools.gov.sg) |
+| 1 Aristotle | Ms Nurul Ain <br>65087-328<br>[nurul_ain_mohamad_ibrahim@schools.gov.sg](mailto:nurul_ain_mohamad_ibrahim@schools.gov.sg) | Mdm Suhana<br>65087-323<br>[norsuhana_sahmat@schools.gov.sg](mailto:norsuhana_sahmat@schools.gov.sg) |
+| 1 Beethoven | Mdm Razia<br>65087-267<br>[abdul_majeeth_razia_sulthana@schools.gov.sg](mailto:abdul_majeeth_razia_sulthana@schools.gov.sg) | Mr Guah<br>65087-314<br>[guah_boon_heng@schools.gov.sg](mailto:guah_boon_heng@schools.gov.sg) |
+| 1 Curie |Ms Shannon Lim<br>65080-659<br>[lim_eu_li@schools.gov.sg](mailto:lim_eu_li@schools.gov.sg) | Mr Hassan<br>65087-300 (Ext 286)<br>[hassan_mulyadi_mohamed_a@moe.edu.sg](mailto:hassan_mulyadi_mohamed_a@moe.edu.sg) |
+| 1 Da Vinci | Ms Nabilah<br>65067-344<br>[nabilah_abdullah@schools.gov.sg](mailto:nabilah_abdullah@schools.gov.sg) | Mrs Clara Koh (SH Aesthetics)<br>65089-455<br>[lim_xiu_fang_clara@schools.gov.sg](mailto:lim_xiu_fang_clara@schools.gov.sg) |
+| 1 Edison | Ms Candice Khoo<br>65067-643<br>[khoo_yun_xuan_candice@schools.gov.sg](mailto:khoo_yun_xuan_candice@schools.gov.sg) | Mdm Adzilah<br>65080-663<br>[noor_adzilah_tahir@schools.gov.sg](mailto:noor_adzilah_tahir@schools.gov.sg) |
+| 1 Frank |Mr Kumar (YH, Lower Primary)<br>65087-311<br>[kanapa_sathis_kumar@schools.gov.sg](mailto:kanapa_sathis_kumar@schools.gov.sg) | Mdm Joy Tan<br>65087-265<br>[tan_boon_hui@schools.gov.sg](mailto:tan_boon_hui@schools.gov.sg) |
+| 1 Galileo | Mdm Nurulhuda<br>65087-325<br>[nurulhuda_md_salleh@schools.gov.sg](mailto:nurulhuda_md_salleh@schools.gov.sg)|Ms Li Li<br>65087-263<br>[li_li@schools.gov.sg](mailto:li_li@schools.gov.sg) |
+| 1 Hillary |Mrs Sharon Seow (ST, Learning Needs LPL)<br>65080-658<br>[chew_sharon@schools.gov.sg](mailto:chew_sharon@schools.gov.sg) | Mrs Chew Yixin<br>65080-662<br>[tan_yixin@schools.gov.sg](mailto:tan_yixin@schools.gov.sg) |
 
 
 ### Subject Teachers

--- a/_about-us/Our People/Primary 2 Teachers.md
+++ b/_about-us/Our People/Primary 2 Teachers.md
@@ -11,16 +11,8 @@ variant: markdown
 
 | Class | Form Teacher | Form Teacher |
 |---|---|---|
-| 2 Aristotle |Ms Nabilah<br>65067-344<br>[nabilah\_abdullah@schools.gov.sg](mailto:nabilah\_abdullah@schools.gov.sg)| Mdm Koh Siew Bee<br>65087-261<br>[koh\_siew\_bee@schools.gov.sg](mailto:koh\_siew\_bee@schools.gov.sg)|
-| 2 Beethoven | Mrs Grace Chua<br>65089-468<br>[grace\_lim\_hui\_leng@schools.gov.sg](mailto:grace\_lim\_hui\_leng@schools.gov.sg)| Mr Sathis Kumar (Year Head, Lower Primary)<br>65087-311<br>[kanapa\_sathis\_kumar@schools.gov.sg](mailto:kanapa\_sathis\_kumar@schools.gov.sg)|
-| 2 Curie | Mdm Nurulhuda<br>65087-325<br>[nurulhuda\_md\_salleh@schools.gov.sg](mailto:nurulhuda\_md\_salleh@schools.gov.sg)|Ms Sumitha<br>65087-315<br>[s\_sumitha@schools.gov.sg](mailto:s\_sumitha@schools.gov.sg)|
-| 2 Da Vinci |Mdm Hailwa<br>65067-641<br>[hailwa\_moree@schools.gov.sg](mailto:hailwa\_moree@schools.gov.sg)| Mr Noel Chan<br>65089-459<br>[noel\_chan\_tze\_sunn@schools.gov.sg](mailto:noel\_chan\_tze\_sunn@schools.gov.sg)|
-| 2 Edison |Ms Shannon Lim<br>65080-659<br>[lim\_eu\_li@schools.gov.sg](mailto:lim\_eu\_li@schools.gov.sg)| Mr Guah <br>65087-314<br>[guah\_boon\_heng@schools.gov.sg](mailto:guah\_boon\_heng@schools.gov.sg)|
-| 2 Frank |Mrs Sharon Seow (ST, Learning Needs LPL)<br>65067-644<br>[chew\_sharon@schools.gov.sg](mailto:chew\_sharon@schools.gov.sg)| Mr Bryon Luo<br>65089-457<br>[luo\_youde\_bryon@schools.gov.sg](mailto:luo\_youde\_bryon@schools.gov.sg)|
-| 2 Galileo | Mdm Munirah<br>65080-656<br>[siti\_nurmunirah\_mohd\_arsad@schools.gov.sg](mailto:siti\_nurmunirah\_mohd\_arsad@schools.gov.sg)| Ms Foo Shi Rui (Level Head, Math)<br>65067-645<br>[foo\_shi\_rui@schools.gov.sg](mailto:foo\_shi\_rui@schools.gov.sg)|
-| 2 Hillary | Ms Candice Khoo<br>65067-643<br>[khoo\_yun\_xuan\_candice@schools.gov.sg](mailto:khoo\_yun\_xuan\_candice@schools.gov.sg)| Mdm Karmila<br>65089-458<br>[nor\_karmila\_hamzah@schools.gov.sg](mailto:nor\_karmila\_hamzah@schools.gov.sg)|
-|
-| | | |
+
+Will be updated soon....
 
 ### Subject Teachers
 
@@ -28,6 +20,6 @@ variant: markdown
 |---|---|
 | Art | Mrs Chew Yi Xin<br>65080-662<br>[tan\_yixin@schools.gov.sg](mailto:tan\_yixin@schools.gov.sg) |
 
-To be updated soon.....
+Will be updated soon....
 
 | |

--- a/_about-us/Our People/Primary 2 Teachers.md
+++ b/_about-us/Our People/Primary 2 Teachers.md
@@ -27,47 +27,7 @@ variant: markdown
 | Subject | Teacher |
 |---|---|
 | Art | Mrs Chew Yi Xin<br>65080-662<br>[tan\_yixin@schools.gov.sg](mailto:tan\_yixin@schools.gov.sg) |
-Art |Mdm Karmila<br>65089-458<br>[nor\_karmila\_hamzah@schools.gov.sg](mailto:nor\_karmila\_hamzah@schools.gov.sg)
-Art | Mdm Adzilah<br>65080-663<br>[noor\_adzilah\_tahir@schools.gov.sg](mailto:noor\_adzilah\_tahir@schools.gov.sg)
-|
-| English Language | Mdm Munirah<br>65080-656<br>[siti\_nurmunirah\_mohd\_arsad@schools.gov.sg](mailto:siti\_nurmunirah\_mohd\_arsad@schools.gov.sg) |
-| English Language | Mdm Ng Cheng Tze<br>65067-344<br>[ng\_cheng\_tze\_a@moe.edu.sg](mailto:ng\_cheng\_tze\_a@moe.edu.sg) |
-English Language | Mrs Grace Chua<br>65089-468<br>[grace\_lim\_hui\_leng@schools.gov.sg](mailto:grace\_lim\_hui\_leng@schools.gov.sg)
-English Language | Mdm Nurulhuda<br>65087-325<br>[nurulhuda\_md\_salleh@schools.gov.sg](mailto:nurulhuda\_md\_salleh@schools.gov.sg)
-English Language | Mdm Hailwa<br>65067-641<br>[hailwa\_moree@schools.gov.sg](mailto:hailwa_moree@schools.gov.sg)
-English Language | Ms Shannon Lim<br>65080-659<br>[lim\_eu\_li@schools.gov.sg](mailto:lim\_eu\_li@schools.gov.sg)
-English Language | Mrs Sharon Seow (ST, Learning Needs LPL)<br>65067-644<br>[chew\_sharon@schools.gov.sg](mailto:chew\_sharon@schools.gov.sg)
-English Language | Mdm Munirah<br>65080-656<br>[siti\_nurmunirah\_mohd\_arsad@schools.gov.sg](mailto:siti\_nurmunirah\_mohd\_arsad@schools.gov.sg)
-English Language | Ms Candice Khoo<br>65067-643<br>[khoo\_yun\_xuan\_candice@schools.gov.sg](mailto:khoo\_yun\_xuan\_candice@schools.gov.sg)
-|
-| Mathematics | Mrs Grace Chua<br>65089-468<br>[grace\_lim\_hui\_leng@schools.gov.sg](mailto:grace\_lim\_hui\_leng@schools.gov.sg) |
- Mathematics | Mdm Nurulhuda<br>65087-325<br>[nurulhuda\_md\_salleh@schools.gov.sg](mailto:nurulhuda\_md\_salleh@schools.gov.sg) |
-  Mathematics | Mdm  Ng Cheng Tze<br>65067-344<br>[ng\_cheng\_tze\_a@moe.edu.sg](mailto:ng\_cheng\_tze\_a@moe.edu.sg) |
- Mathematics | Ms Shannon Lim<br>65080-659<br>[lim\_eu\_li@schools.gov.sg](mailto:lim\_eu\_li@schools.gov.sg) |
-  Mathematics | Mrs Sharon Seow (ST, Learning Needs LPL)<br>65067-644<br>[chew\_sharon@schools.gov.sg](mailto:chew\_sharon@schools.gov.sg) |
- Mathematics | Ms Foo Shi Rui (LH, Math)<br>65067-645<br>[foo\_shi\_rui@schools.gov.sg](mailto:foo\_shi\_rui@schools.gov.sg) |
- Mathematics | Ms Candice Khoo<br>65067-643<br>[khoo\_yun\_xuan\_candice@schools.gov.sg](mailto:khoo\_yun\_xuan\_candice@schools.gov.sg) |
- Mathematics |Mdm Kumutha<br>65089-458<br>[kumutha\_jayandran@moe.edu.sg](mailto:kumutha\_jayandran@moe.edu.sg) |
- Mathematics | Mrs Kishore (Magdalene Tan)<br>65089-452<br>[tan\_kai\_lin\_magdalene@schools.gov.sg](mailto:tan\_kai\_lin\_magdalene@schools.gov.sg) |
- Mathematics |Mrs Gracelyn Tham<br>65067-648<br>[lim\_ai\_zhen\_gracelyn@schools.gov.sg](mailto:lim\_ai\_zhen\_gracelyn@schools.gov.sg)
-|
-| Chinese Language | Mdm Koh Siew Bee<br>65087-261<br>[koh\_siew\_bee@schools.gov.sg](mailto:koh\_siew\_bee@schools.gov.sg) |
-Chinese Language |Mdm Tan Hui Yang<br>65083-171<br>[tan\_hui\_yang@schools.gov.sg](mailto:tan\_hui\_yang@schools.gov.sg) |
-Chinese Language |Mdm Li Li<br>65087-263<br>[li\_li@schools.gov.sg](mailto:li\_li@schools.gov.sg) |
-Chinese Language | Mr Guah <br>65087-314<br>[guah\_boon\_heng@schools.gov.sg](mailto:guah\_boon\_heng@schools.gov.sg) |
-Chinese Language | Mdm Joy Tan<br>65087-265<br>[tan\_boon\_hui@schools.gov.sg](mailto:tan\_boon\_hui@schools.gov.sg) |
-Chinese Language |Mdm Hwee Yeng<br>65087-268<br>[lim\_hwee\_yeng@schools.gov.sg](mailto:lim\_hwee\_yeng@schools.gov.sg) |
-|Chinese Language | Mdm Yong<br>65087-273<br>[yong\_puay\_pin\_a@moe.edu.sg](mailto:yong\_puay\_pin\_a@moe.edu.sg)
-|
-|Malay Language | Ms Nurbayah<br>65087-300 (Ext 651)<br>[nurbayah\_ismail@schools.gov.sg](mailto:nurbayah\_ismail@schools.gov.sg) |
-| Malay Language  | Mdm Shikin<br>65087-320<br>[noorashikin\_zainuldin@schools.gov.sg](mailto:noorashikin\_zainuldin@schools.gov.sg) 
-|
-| Tamil Language  | Ms Sumitha<br>65087-315<br>[s\_sumitha@schools.gov.sg](mailto:s\_sumitha@schools.gov.sg) 
-|
-| Music| Mr Bryon Luo <br>65089-457<br>[luo\_youde\_bryon@schools.gov.sg](mailto:luo\_youde\_bryon@schools.gov.sg) |
-| Music |Mrs Clara Koh (SH, Aesthetics)<br>65089-455<br>[lim\_xiu\_fang\_clara@schools.gov.sg](mailto:lim\_xiu\_fang\_clara@schools.gov.sg) |
-|
-|Physical Education &amp; Health Education | Mr Noel Chan<br>65083-173<br>[noel\_chan\_tze\_sunn@schools.gov.sg](mailto:noel\_chan\_tze\_sunn@schools.gov.sg) |
-|Physical Education &amp; Health Education | Mr Nadeem<br>65087-276<br>[mohamed\_nadeem@schools.gov.sg](mailto:mohamed\_nadeem@schools.gov.sg) |
-|Physical Education &amp; Health Education | Mrs Michelle Khoo (SH, PE &amp; CCA)<br>65087-278<br>[lee\_jing\_wen\_michelle@schools.gov.sg](mailto:lee\_jing\_wen\_michelle@schools.gov.sg) |
+
+To be updated soon.....
+
 | |

--- a/_about-us/Our People/Primary 3 Teachers.md
+++ b/_about-us/Our People/Primary 3 Teachers.md
@@ -11,58 +11,12 @@ variant: markdown
 
 | Class | Form Teacher | Form Teacher |
 |---|---|---|
-| 3 Aristotle |Ms Joanne Ko<br>65089-461<br>[ko\_hiang@schools.gov.sg](mailto:ko\_hiang@schools.gov.sg) | Mr Nadeem<br>65087-276<br>[mohamed\_nadeem@schools.gov.sg](mailto:mohamed\_nadeem@schools.gov.sg) |
- 3 Beethoven | Mdm Heng Wei Shan<br>65089-450<br>[heng\_wei\_shan\_a@schools.gov.sg](mailto:heng\_wei\_shan\_a@schools.gov.sg) | Mrs Yvonne Seow<br>65067-646<br>[lim\_yi\_min\_yvonne@schools.gov.sg](mailto:lim\_yi\_min\_yvonne@schools.gov.sg)
-| 3 Curie |Mdm Suhana<br>65087-318<br>[norsuhana\_sahmat@schools.gov.sg](mailto:norsuhana\_sahmat@schools.gov.sg) | Mr Teng Tse Peng (YH, Middle Primary)<br>65087-310<br>[teng\_tse\_peng\_a@schools.gov.sg](mailto:teng\_tse\_peng\_a@schools.gov.sg) |
-| 3 Da Vinci | Ms Priscilla Teng<br>65087-326<br>[teng\_yu\_hui\_priscilla@schools.gov.sg](mailto:teng\_yu\_hui\_priscilla@schools.gov.sg) |Mdm Nabilah<br>65087-319<br>[nabilah\_abdul\_rahman@schools.gov.sg](mailto:nabilah\_abdul\_rahman@schools.gov.sg) |
-| 3 Edison |Mdm Asyikin<br>65067-343<br>[nur\_asyikin\_mohd\_agos@schools.gov.sg](mailto:nur\_asyikin\_mohd\_agos@schools.gov.sg) | Ms Cher Xin Joo<br>65087-260<br>[cher\_xin\_joo@schools.gov.sg](mailto:cher\_xin\_joo@schools.gov.sg) |
-| 3 Frank | Mrs Saj<br>65089-454<br>[vanisree\_sajjan@schools.gov.sg](mailto:vanisree\_sajjan@schools.gov.sg) | Ms Audrey Loke (HOD, Math)<br>65083-170<br>[loke\_ai\_guat\_audrey@schools.gov.sg](mailto:loke\_ai\_guat\_audrey@schools.gov.sg) |
-| 3 Galileo | Mrs Kishore (Magdalene Tan)<br>65089-452<br>[tan\_kai\_lin\_magdalene@schools.gov.sg](mailto:tan\_kai\_lin\_magdalene@schools.gov.sg) |Ms Kang<br>65087-269<br>[kang\_chao@schools.gov.sg](mailto:kang\_chao@schools.gov.sg) |
+
+Will be updated soon....
 
 ### Subject Teachers
 
 | Subject | Teacher |
 |---|---|
-| Art | Mr Fong Yan Kin<br>65080-661<br>[fong_yan_kin@schools.gov.sg](mailto:fong_yan_kin@schools.gov.sg)|
-| Art | Mdm Adzilah<br>65080-663<br>[noor\_adzilah\_tahir@schools.gov.sg](mailto:noor\_adzilah\_tahir@schools.gov.sg)|
-|
-| English Language | Ms Hidayah<br>65089-469<br>[nur\_hidayah\_mohshin@schools.gov.sg](mailto:nur\_hidayah\_mohshin@schools.gov.sg)|
-English Language | Mr Sathis Kumar (YH, Lower Primary)<br>65087-311<br>[kanapa\_sathis\_kumar@schools.gov.sg](mailto:kanapa\_sathis\_kumar@schools.gov.sg)|
-English Language |Mrs Sarah Tan<br>65067-348<br>[sarah\_yu\_xueli@schools.gov.sg](mailto:sarah\_yu\_xueli@schools.gov.sg)|
-English Language | Ms Priscilla Teng<br>65087-326<br>[teng\_yu\_hui\_priscilla@schools.gov.sg](mailto:teng\_yu\_hui\_priscilla@schools.gov.sg)|
-English Language | Ms Joanne Ko<br>65089-461<br>[ko\_hiang@schools.gov.sg](mailto:ko\_hiang@schools.gov.sg)|
-English Language | Mrs Saj<br>65089-454<br>[vanisree\_sajjan@moe.edu.sg](mailto:vanisree\_sajjan@moe.edu.sg)|
-English Language | Ms Nicholyn Teo (AYH, Middle Primary)<br>65087-323<br>[nicholyn_teo@schools.gov.sg](mailto:nicholyn_teo@schools.gov.sg)|
-|
-| Mathematics | Mrs Yvonne Seow<br>65067-646<br>[lim\_yi\_min\_yvonne@schools.gov.sg](mailto:lim\_yi\_min\_yvonne@schools.gov.sg)|
-Mathematics | Mr Dallon Kang<br>65083-173<br>[kang\_zhenlin\_dallon@moe.edu.sg](mailto:kang\_zhenlin\_dallon@moe.edu.sg)|
-Mathematics |Madam Seah Wai Fang<br>65087-300 (Ext 242)<br>[seah\_wai\_fang\_a@moe.edu.sg](mailto:seah\_wai\_fang\_a@moe.edu.sg)|
-Mathematics | Mr Shaun Png<br>65080-666<br>[png\_jia\_shun@schools.gov.sg](mailto:png\_jia\_shun@schools.gov.sg)|
-Mathematics | Ms Audrey Loke (HOD, Math)<br>65083-170<br>[loke\_ai\_guat\_audrey@schools.gov.sg](mailto:loke\_ai\_guat\_audrey@schools.gov.sg)|
-Mathematics | Mrs Kishore (Magdalene Tan)<br>65089-452<br>[tan\_kai\_lin\_magdalene@schools.gov.sg](mailto:tan\_kai\_lin\_magdalene@schools.gov.sg)|
-Mathematics | Mr Guna<br>65080-668<br>[sargunan\_ilangovan@schools.gov.sg](mailto:sargunan\_ilangovan@schools.gov.sg)|
-|
-Science | Mr Senthil [Zack] , (SH, Student Well-Being)<br>65080-664<br>[subramaniyan\_senthil@schools.gov.sg](mailto:subramaniyan\_senthil@schools.gov.sg)|
-Science | Mdm Asyikin<br>65067-343<br>[nur\_asyikin\_mohd\_agos@schools.gov.sg](mailto:nur\_asyikin\_mohd\_agos@schools.gov.sg)|
-Science | Ms Joanne Ko <br>65089-461<br>[ko\_hiang@schools.gov.sg](mailto:ko\_hiang@schools.gov.sg)|
-Science | Mrs Tan Lirong <br>65080-669<br>[sun\_lirong@schools.gov.sg](mailto:sun\_lirong@schools.gov.sg)|
-Science | Mrs Michelle Wee <br>65080-667<br>[michelle\_tyoh\_whei\_theng@schools.gov.sg](mailto:michelle\_tyoh\_whei\_theng@schools.gov.sg)|
-Science | Mrs Kishore (Magdalene Tan)<br>65089-452<br>[tan\_kai\_lin\_magdalene@schools.gov.sg](mailto:tan\_kai\_lin\_magdalene@schools.gov.sg)|
-|
-| Chinese Language| Mr Rave Tay (HOD, MTL)<br>65083-172<br>[tay\_tze\_rong@schools.gov.sg](mailto:tay\_tze\_rong@schools.gov.sg)|
-Chinese Language| Ms Kang<br>65087-269<br>[kang\_chao@schools.gov.sg](mailto:kang\_chao@schools.gov.sg)|
-Chinese Language|Mr Zhou Wencong (HOD,SM)<br>65087-322<br>[zhou\_wencong@schools.gov.sg](mailto:zhou\_wencong@schools.gov.sg)|
-Chinese Language| Ms Cher Xin Joo<br>65087-260<br>[cher\_xin\_joo@schools.gov.sg](mailto:schools.gov.sg)|
-Chinese Language| Mdm Heng Wei Shan<br>65089-450<br>[heng\_wei\_shan\_a@schools.gov.sg](mailto:heng\_wei\_shan\_a@schools.gov.sg)|
-Chinese Language| Mr Teng Tse Peng<br>65087-310<br>[teng\_tse\_peng\_a@schools.gov.sg](mailto:teng\_tse\_peng\_a@schools.gov.sg)|
-Chinese Language| Mdm Teo Siow Yee (ST, SEN)<br>65087-270<br>[teo\_siow\_yee@schools.gov.sg](mailto:teo\_siow\_yee@schools.gov.sg)
-|
-| Malay Language| Mdm Nabilah<br>65087-318<br>[nabilah\_abdul\_rahman@schools.gov.sg](mailto:nabilah\_abdul\_rahman@schools.gov.sg)|
-| Malay Language| Mdm Suhana<br>65087-319<br>[norsuhana\_sahmat@schools.gov.sg](mailto:norsuhana\_sahmat@schools.gov.sg)|
-|
-| Music | Ms Rebecca Lau (ST, Music)<br>65089-456<br>[rebecca\_lau\_yuen\_sun@schools.gov.sg](mailto:rebecca\_lau\_yuen\_sun@schools.gov.sg)|
-Music | Mr Bryon Luo<br>65080-662<br>[luo\_youde\_bryon@schools.gov.sg](mailto:luo\_youde\_bryon@schools.gov.sg)|
-|
-| Physical Education and Health Education | Mr Nadeem<br>65087-276 <br>[mohamed\_nadeem@schools.gov.sg](mailto:mohamed\_nadeem@schools.gov.sg)|
-| Physical Education and Health Education |Mrs Valerie Koh<br>65087-279<br>[valerie\_koh\_sock\_hwee@schools.gov.sg](mailto:valerie\_koh\_sock\_hwee@schools.gov.sg)|
-| Physical Education and Health Education | Mr Noel Chan<br>65083-173<br>[noel\_chan\_tze\_sunn@schools.gov.sg](mailto:noel\_chan\_tze\_sunn@schools.gov.sg)|
+
+Will be updated soon....

--- a/_about-us/Our People/Primary 4 Teachers.md
+++ b/_about-us/Our People/Primary 4 Teachers.md
@@ -11,65 +11,10 @@ variant: markdown
 
 | Class | Form Teacher | Form Teacher |
 |---|---|---|
-| 4 Aristotle | Mdm Esther Tay (LH, Science)<br>65087-330<br>[tay\_wei\_jing@schools.gov.sg](mailto:tay\_wei\_jing@schools.gov.sg)| Mdm Joy Tan<br>65087-265<br>[tan\_boon\_hui@schools.gov.sg](mailto:tan\_boon\_hui@schools.gov.sg)|
-|4 Beethoven |Mrs Clara Koh (SH, Aesthetics)<br>65089-455<br>[lim_xiu_fang_clara@schools.gov.sg](mailto:lim_xiu_fang_clara@schools.gov.sg)|  Mdm Adzilah<br>65080-663<br>[noor\_adzilah\_tahir@schools.gov.sg](mailto:noor\_adzilah\_tahir@schools.gov.sg)|
-| 4 Curie |Ms Nicholyn Teo (AYH, Middle Primary)<br>65087-323<br>[nicholyn_teo@schools.gov.sg](mailto:nicholyn_teo@schools.gov.sg)| Mdm Tan Hui Yang<br>65083-171<br>[tan\_hui\_yang@schools.gov.sg](mailto:tan\_hui\_yang@schools.gov.sg)|
-| 4 Da Vinci | Ms Nurul Ain (ST, English Language) <br>65087-328<br>[nurul\_ain\_mohamad\_ibrahim@schools.gov.sg](mailto:nurul\_ain\_mohamad\_ibrahim@schools.gov.sg)| Mdm Elyani (ST, Malay Language)<br>65080-654<br>[elyani\_mohamed@schools.gov.sg](mailto:elyani\_mohamed@schools.gov.sg)|
-| 4 Edison |Mrs Jodie Siow<br>65087-316<br>[yeo\_mui\_hong@schools.gov.sg](mailto:yeo\_mui\_hong@schools.gov.sg)| Ms Loo Yee<br>65087-271<br>[lee_loo_yee@schools.gov.sg](mailto:lee_loo_yee@schools.gov.sg)|
-| 4 Frank | Mr Isa<br>65067-346<br>[mohamed\_isa\_b\_osman@schools.gov.sg](mailto:mohamed\_isa\_b\_osman@schools.gov.sg)|Mdm Li Li<br>65087-263<br>[li\_li@schools.gov.sg](mailto:li\_li@schools.gov.sg)|
-| 4 Galileo | Mdm Josephine Kee<br>65067-342<br>[kee\_wan\_cheng@schools.gov.sg](mailto:kee\_wan\_cheng@schools.gov.sg)|Mdm Shikin <br>65087-320<br>[noorashikin\_zainuldin@schools.gov.sg](mailto:noorashikin\_zainuldin@schools.gov.sg)|
+| 
+
+Will be updated soon....
 
 ### Subject Teachers
 
-| Subject | Teacher |
-|---|---|
-| Art | Mdm Adzilah<br>65080-663<br>[noor\_adzilah\_tahir@schools.gov.sg](mailto:noor\_adzilah\_tahir@schools.gov.sg)|
-| Art  | Mr Fong Yan Kin<br>65080-661<br>[fong_yan_kin@schools.gov.sg](mailto:fong_yan_kin@schools.gov.sg)|
-| 
-| English Language | Mrs Serene Yue<br>65067-345<br>[wong\_may\_san\_serene@schools.gov.sg](mailto:wong\_may\_san\_serene@schools.gov.sg)|
-English Language | Mdm Kalpana (LH, EL)<br>65067-349<br>[kalpana_manimohan@schools.gov.sg](mailto:kalpana_manimohan@schools.gov.sg)
-English Language | Ms Nicholyn Teo (AYH, Middle Primary)<br>65087-323<br>[nicholyn_teo@schools.gov.sg](mailto:nicholyn_teo@schools.gov.sg)
-English Language |Ms Nurul Ain (ST, English Language) <br>65087-328<br>[nurul\_ain\_mohamad\_ibrahim@schools.gov.sg](mailto:nurul\_ain\_mohamad\_ibrahim@schools.gov.sg)
-English Language | Mdm Siti Norida<br>65087-327<br>[siti\_norida\_hassim@moe.edu.sg](mailto:siti\_norida\_hassim@moe.edu.sg)
-English Language | Mr Isa<br>65067-346<br>[mohamed\_isa\_b\_osman@schools.gov.sg](mailto:mohamed\_isa\_b\_osman@schools.gov.sg)
-English Language | Ms Rachel Loh<br>65067-640<br>[loh\_hui\_xian\_rachel@schools.gov.sg](mailto:loh\_hui\_xian\_rachel@schools.gov.sg)
-English Language | Mdm Subaitha<br>65089-467<br>[subaitha\_bee\_sahul\_hameed@moe.edu.sg](mailto:subaitha\_bee\_sahul\_hameed@moe.edu.sg)
-|
-| Mathematics | Mdm Esther Tay (LH, Science)<br>65087-330<br>[tay\_wei\_jing@schools.gov.sg](mailto:tay\_wei\_jing@schools.gov.sg)|
-Mathematics | Mrs Priscillia Chen (AYH, Upper Primary)<br>65087-274<br>[tan\_yi\_siu\_priscillia@schools.gov.sg](mailto:tan\_yi\_siu\_priscillia@schools.gov.sg)
-Mathematics | Mrs Jodie Siow<br>65087-316<br>[yeo\_mui\_hong@schools.gov.sg](mailto:yeo\_mui\_hong@schools.gov.sg)
-Mathematics | Ms Nicole Chee<br>65067-340<br>[chee\_shu\_rong\_nicole@schools.gov.sg](mailto:chee\_shu\_rong\_nicole@schools.gov.sg)
-Mathematics | Mdm Josephine Kee<br>65067-342<br>[kee\_wan\_cheng@schools.gov.sg](mailto:kee\_wan\_cheng@schools.gov.sg)
-Mathematics | Mdm Seah Wai Fang<br>65087-300 (Ext 242)<br>[seah\_wai\_fang\_a@moe.edu.sg](mailto:seah\_wai\_fang\_a@moe.edu.sg)
-Mathematics | Mr John Leong<br>65089-462<br>[leong\_john\_woon@moe.edu.sg](mailto:leong\_john\_woon@moe.edu.sg)
-Mathematics | Mrs Trinidad<br>65087-300 (Ext 241)<br>[alexandria\_koh@moe.edu.sg](mailto:alexandria\_koh@moe.edu.sg)
-|
-| Science | Mdm Esther Tay (LH, Science)<br>65087-330<br>[tay\_wei\_jing@schools.gov.sg](mailto:tay\_wei\_jing@schools.gov.sg)|
-Science |Mr John Leong<br>65089-462<br>[leong\_john\_woon@moe.edu.sg](mailto:leong\_john\_woon@moe.edu.sg)|
-Science | Mrs Tan Lirong<br>65080-669<br>[sun\_lirong@schools.gov.sg](mailto:sun\_lirong@schools.gov.sg)|
-Science | Mrs Jodie Siow<br>65087-316<br>[yeo\_mui\_hong@schools.gov.sg](mailto:yeo\_mui\_hong@schools.gov.sg)|
-Science | Mdm Josephine Kee<br>65067-342<br>[kee\_wan\_cheng@schools.gov.sg](mailto:kee\_wan\_cheng@schools.gov.sg)
-Science | Ms Joanne Ko<br>65089-461<br>[ko\_hiang@schools.gov.sg](mailto:ko\_hiang@schools.gov.sg)
-Science | Ms Seirrah<br>65087-300 (Ext 285)<br>[lim\_mei\_fen@moe.edu.sg](mailto:lim\_mei\_fen@moe.edu.sg)
-Science | Mrs Yvonne Seow<br>65067-646<br>[lim\_yi\_min\_yvonne@schools.gov.sg](mailto:lim\_yi\_min\_yvonne@schools.gov.sg)|
-|
-| Chinese Language | Mdm Koh Siew Bee<br>65087-261<br>[koh\_siew\_bee@schools.gov.sg](mailto:koh\_siew\_bee@schools.gov.sg)|
-Chinese Language | Mr Teng Tse Peng (YH, Middle Primary)<br>65087-310<br>[teng\_tse\_peng\_a@schools.gov.sg](mailto:teng\_tse\_peng\_a@schools.gov.sg)|
-Chinese Language | Mdm Li Li<br>65087-263<br>[li\_li@schools.gov.sg](mailto:li\_li@schools.gov.sg)|
-Chinese Language | Mdm Tan Hui Yang<br>65083-171<br>[tan\_hui\_yang@schools.gov.sg](mailto:tan\_hui\_yang@schools.gov.sg)|
-Chinese Language | Mdm Joy Tan<br>65087-265<br>[tan\_boon\_hui@schools.gov.sg](mailto:tan\_boon\_hui@schools.gov.sg)|
-Chinese Language | Mr Warren Thin (HOD, ICT)<br>65080-652<br>[thin\_dongqi@schools.gov.sg](mailto:thin\_dongqi@schools.gov.sg)|
-Chinese Language | Ms Loo Yee<br>65087-271<br>[lee_loo_yee@schools.gov.sg](mailto:lee_loo_yee@schools.gov.sg)|
-|
-| Malay Language | Mdm Elyani (ST, Malay Language)<br>65080-654<br>[elyani\_mohamed@schools.gov.sg](mailto:elyani\_mohamed@schools.gov.sg)|
- Malay Language | Mdm Shikin<br>65087-320<br>[noorashikin\_zainuldin@schools.gov.sg](mailto:noorashikin\_zainuldin@schools.gov.sg)
-|
-| Music | Ms Rebecca Lau (ST, Music)<br>65089-456<br>[rebecca_lau_yuen_sun@schools.gov.sg](mailto:rebecca_lau_yuen_sun@moe.edu.sg)|
-| Music | Mr Bryon Luo<br>65080-662<br>[luo\_youde\_bryon@schools.gov.sg](mailto:luo\_youde\_bryon@schools.gov.sg)|
-|
-| Physical Education and Health Education | Miss Valerie Koh<br>65087-277<br>[valerie_koh_sock_hwee@schools.gov.sg](mailto:valerie_koh_sock_hwee@schools.gov.sg)|
-| Physical Education and Health Education | Mr Nadeem<br>65087-276<br>[mohamed_nadeem@schools.gov.sg](mailto:mohamed_nadeem@schools.gov.sg)|
-| Physical Education and Health Education | Mr Noel Chan<br>65083-173<br>[noel_chan_tze_sunn@schools.gov.sg](mailto:noel_chan_tze_sunn@schools.gov.sg)|
-| Physical Education and Health Education | Mrs Michelle Khoo (SH, PE &amp; CCA) <br>65087-278<br>[lee_jing_wen_michelle@schools.gov.sg](mailto:lee_jing_wen_michelle@schools.gov.sg)|
-| Physical Education and Health Education | Mr Rafiei <br>65087-275<br>[mohamad\_rafiei\_sakeyam@schools.gov.sg](mailto:mohamad\_rafiei\_sakeyam@schools.gov.sg)|
-| Physical Education and Health Education | Ms Nazurah<br>65087-275<br>[nazurah\_syazana\_nordin@schools.gov.sg](mailto:nazurah\_syazana\_nordin@schools.gov.sg)|
+Will be updated soon....

--- a/_about-us/Our People/Primary 5 Teachers.md
+++ b/_about-us/Our People/Primary 5 Teachers.md
@@ -11,61 +11,12 @@ variant: markdown
 
 | Class | Form Teacher | Form Teacher |
 |---|---|---|
-| 5 Aristotle | Mdm Kalpana (LH, English Language)<br>65067-349<br>[kalpana\_manimohan@schools.gov.sg](mailto:kalpana\_manimohan@schools.gov.sg) | Mdm Zhang Yue<br>65087-262<br>[zhang\_yue\_a@schools.gov.sg](mailto:zhang\_yue\_a@schools.gov.sg) |
-| 5 Beethoven | Ms Nicole Chee<br>65067-340<br>[chee\_shu\_rong\_nicole@schools.gov.sg](mailto:chee\_shu\_rong\_nicole@schools.gov.sg) | Mdm Hasanah (School Staff Developer)<br>65080-660<br>[nur\_hasanah\_osman@schools.gov.sg](mailto:nur\_hasanah\_osman@schools.gov.sg) |
-| 5 Curie | Mrs Sarah Tan<br>65067-348<br>[sarah\_yu\_xueli@schools.gov.sg](mailto:sarah\_yu\_xueli@schools.gov.sg) | Mr Rave Tay (HOD, MTL)<br>65083-172<br>[tay\_tze\_rong@schools.gov.sg](mailto:tay\_tze\_rong@schools.gov.sg) |
-| 5 Da Vinci | Mr Senthil [Zack] (SH, Student Well-Being)<br>65080-664<br>[subramaniyan\_senthil@schools.gov.sg](mailto:subramaniyan\_senthil@schools.gov.sg) | Miss Germaine Quek<br>65087-272<br>[germaine\_quek\_jiamin@schools.gov.sg](mailto:germaine\_quek\_jiamin@schools.gov.sg) |
-| 5 Edison | Mrs Serene Yue<br>65067-345<br>[wong\_may\_san\_serene@schools.gov.sg](mailto:wong\_may\_san\_serene@schools.gov.sg) | Mr Gerald Wong (HOD, Science)<br>65087-313<br>[gerald\_wong\_yew\_meng@schools.gov.sg](mailto:gerald\_wong\_yew\_meng@schools.gov.sg) |
-| 5 Frank | Mrs Priscillia Chen (AYH, Upper Primary)<br>65087-274<br>[tan\_yi\_siu\_priscillia@schools.gov.sg](mailto:tan\_yi\_siu\_priscillia@schools.gov.sg) | Mr Rafiei<br>65087-275<br>[mohamad\_rafiei\_sakeyam@schools.gov.sg](mailto:mohamad\_rafiei\_sakeyam@schools.gov.sg) |
-| | | |
+
+Will be updated soon....
 
 ### Subject Teachers
 
 | Subject | Teacher |
 |---|---|
-| Art | Mdm Adzilah<br>65080-663<br>[noor\_adzilah\_tahir@schools.gov.sg](mailto:noor\_adzilah\_tahir@schools.gov.sg) |
-Art | Mdm Karmila<br>65089-458<br>[nor\_karmila\_hamzah@schools.gov.sg](mailto:nor\_karmila\_hamzah@schools.gov.sg)
-Art | Mrs Chew Yixin<br>65080-662<br>[tan\_yixin@schools.gov.sg](mailto:tan\_yixin@schools.gov.sg)
-|
-| English Language | Mdm Kalpana (LH, EL)<br>65067-349<br>[kalpana\_manimohan@schools.gov.sg](mailto:kalpana\_manimohan@schools.gov.sg) |
- English Language | Mdm Hasanah (School Staff Developer)<br>65080-660<br>[nur\_hasanah\_osman@schools.gov.sg](mailto:nur\_hasanah\_osman@schools.gov.sg) |
- English Language | Mrs Sarah Tan<br>65067-348<br>[sarah\_yu\_xueli@schools.gov.sg](mailto:sarah\_yu\_xueli@schools.gov.sg)
- English Language | Mr Senthil [Zack] (SH, Student Well-Being)<br>65080-664<br>[subramaniyan\_senthil@schools.gov.sg](mailto:subramaniyan\_senthil@schools.gov.sg) |
- English Language |Mrs Serene Yue<br>65067-345<br>[wong\_may\_san\_serene@schools.gov.sg](mailto:wong\_may\_san\_serene@schools.gov.sg) |
- English Language | Ms Priscilla Teng<br>65087-326<br>[teng\_yu\_hui\_priscilla@schools.gov.sg](mailto:teng\_yu\_hui\_priscilla@schools.gov.sg) | 
- English Language | Mrs Saj<br>65089-454<br>[vanisree\_sajjan@schools.gov.sg](mailto:vanisree\_sajjan@schools.gov.sg) | 
-|
-| Mathematics  | Mrs Trinidad<br>65087-300 (Ext 241)<br>[alexandria\_koh@moe.edu.sg](mailto:alexandria\_koh@moe.edu.sg) |
- Mathematics  | Ms Nicole Chee<br>65067-340<br>[chee\_shu\_rong\_nicole@schools.gov.sg](mailto:chee\_shu\_rong\_nicole@schools.gov.sg) |
-  Mathematics  | Ms Foo Shi Rui (LH, Math)<br>65089-457<br>[foo\_shi\_rui@schools.gov.sg](mailto:foo\_shi\_rui@schools.gov.sg) |
- Mathematics  | Mdm Asyikin<br>65067-343<br>[nur\_asyikin\_mohd\_agos@schools.gov.sg](mailto:nur\_asyikin\_mohd\_agos@schools.gov.sg) |
- Mathematics  |Mrs Priscillia Chen<br>65087-274<br>[tan\_yi\_siu\_priscillia@schools.gov.sg](mailto:tan\_yi\_siu\_priscillia@schools.gov.sg) |
- Mathematics  |Mrs Yvonne Seow<br>65067-646<br>[lim\_yi\_min\_yvonne@schools.gov.sg](mailto:lim\_yi\_min\_yvonne@schools.gov.sg)
- Mathematics  | Mdm Kumutha<br>65083-179<br>[kumutha\_jayandran@moe.edu.sg](mailto:kumutha\_jayandran@moe.edu.sg) | |
-|
-| Science | Mr Senthil [Zack] (SH, Student Well-Being)<br>65080-664<br>[subramaniyan\_senthil@schools.gov.sg](mailto:subramaniyan\_senthil@schools.gov.sg) |
-Science | Ms Nicole Chee<br>65067-340<br>[chee\_shu\_rong\_nicole@schools.gov.sg](mailto:chee\_shu\_rong\_nicole@schools.gov.sg) |
-Science | Mr Gerald Wong (HOD, Science)<br>65087-313<br>[gerald\_wong\_yew\_meng@schools.gov.sg](mailto:gerald\_wong\_yew\_meng@schools.gov.sg) |
-Science | Mrs Priscillia Chen<br>65087-274<br>[tan\_yi\_siu\_priscillia@schools.gov.sg](mailto:tan\_yi\_siu\_priscillia@schools.gov.sg) |
-Science | Ms Seirrah<br>65087-300 (Ext 285)<br>[lim\_mei\_fen@moe.edu.sg](mailto:lim\_mei\_fen@moe.edu.sg)
-Science | Mr John Leong<br>65089-462<br>[leong\_john\_woon@moe.edu.sg](mailto:leong\_john\_woon@moe.edu.sg) |
-Science | Mr Kelvin Chia<br>65080-665<br>[chia\_peng\_lin\_kelvin@schools.gov.sg](mailto:chia\_peng\_lin\_kelvin@schools.gov.sg)  |
-|
-| Chinese Language | Mdm Zhang Yue<br>65087-262<br>[zhang\_yue\_a@schools.gov.sg](mailto:zhang\_yue\_a@schools.gov.sg) |
-Chinese Language | Mdm Jane Mah<br>65087-267<br>[mah\_zhiwei\_jane@schools.gov.sg](mailto:mah\_zhiwei\_jane@schools.gov.sg) |
-Chinese Language |Miss Germaine Quek<br>65087-272<br>[germaine\_quek\_jiamin@schools.gov.sg](mailto:germaine\_quek\_jiamin@schools.gov.sg) |
-Chinese Language | Mr Guah <br>65087-314<br>[guah\_boon\_heng@schools.gov.sg](mailto:guah\_boon\_heng@schools.gov.sg) |
-Chinese Language |Ms Kang<br>65087-269<br>[kang\_chao@schools.gov.sg](mailto:kang\_chao@schools.gov.sg) |
-Chinese Language | Mr&nbsp;Rave Tay&nbsp;&nbsp;(HOD, MTL)<br>65083-172<br>[tay\_tze\_rong@schools.gov.sg](mailto:tay\_tze\_rong@schools.gov.sg) |
-Chinese Language |Mdm Yong<br>65087-273<br>[yong\_puay\_pin\_a@moe.edu.sg](mailto:yong\_puay\_pin\_a@moe.edu.sg)
-|
-|Malay Language| Mdm Masturah (SH, ML)<br>65087-317<br>[masturah\_salleh@schools.gov.sg](mailto:masturah\_salleh@schools.gov.sg) |
-Malay Language| Mdm Shikin<br>65087-320<br>[noorashikin\_zainuldin@schools.gov.sg](mailto:noorashikin\_zainuldin@schools.gov.sg) |
-Malay Language| Mdm Suhana<br>65087-318<br>[norsuhana\_sahmat@schools.gov.sg](mailto:norsuhana\_sahmat@schools.gov.sg)
-|
-Music| Ms Rebecca Lau (ST, Music)<br>65089-456<br>[rebecca\_lau\_yuen\_sun@schools.gov.sg](mailto:rebecca\_lau\_yuen\_sun@schools.gov.sg) |
-Music| Mrs Clara Koh (SH, Aesthetics)<br>65089-455<br>[lim\_xiu\_fang\_clara@schools.gov.sg](mailto:lim\_xiu\_fang\_clara@schools.gov.sg)
-Music| Mr Bryon Luo<br>65089-457<br>[luo\_youde\_bryon@schools.gov.sg](mailto:luo\_youde\_bryon@schools.gov.sg) |
-|
-| Physical Education and Health Education | Mr Rafiei<br>65087-275<br>[mohamad\_rafiei\_sakeyam@schools.gov.sg](mailto:mohamad\_rafiei\_sakeyam@schools.gov.sg) |
-Physical Education and Health Education | Ms Nazurah<br>65087-275)<br>[nazurah\_syazana\_nordin@schools.gov.sg](mailto:nazurah\_syazana\_nordin@schools.gov.sg) |
+
+Will be updated soon....

--- a/_about-us/Our People/Primary 6 Teachers.md
+++ b/_about-us/Our People/Primary 6 Teachers.md
@@ -11,65 +11,13 @@ variant: markdown
 
 | Class | Form Teacher | Form Teacher |
 |---|---|---|
-| 6 Aristotle | Ms Hidayah<br>65089-469<br>[nur\_hidayah\_mohshin@schools.gov.sg](mailto:nur\_hidayah\_mohshin@schools.gov.sg) |Mr Warren Thin (HOD, ICT)<br>65080-652<br>[thin\_dongqi@schools.gov.sg](mailto:thin\_dongqi@schools.gov.sg) |
-| 6 Beethoven |Mdm Leong Fong Fong<br>65080-655<br>[leong\_fong\_fong@schools.gov.sg](mailto:leong\_fong\_fong@schools.gov.sg) | Mr Zhou Wencong (HOD, SM)<br>65087-322<br>[zhou\_wencong@schools.gov.sg](mailto:zhou\_wencong@schools.gov.sg) |
-| 6 Curie | Mrs Irene Ang (YH, Upper Primary)<br>65087-312<br>[irene\_chia@schools.gov.sg](mailto:irene\_chia@schools.gov.sg) | Ms Rebecca Lau (ST, Music)<br>65089-456<br>[rebecca\_lau\_yuen\_sun@schools.gov.sg](mailto:rebecca\_lau\_yuen\_sun@schools.gov.sg) |
-| 6 Da Vinci |Mr Kelvin Chia (ST, Science)<br>65080-665<br>[chia\_peng\_lin\_kelvin@schools.gov.sg](mailto:chia\_peng\_lin\_kelvin@schools.gov.sg) | Mrs Chew Yixin<br>65080-662<br>[tan\_yixin@schools.gov.sg](mailto:tan\_yixin@schools.gov.sg) |
-| 6 Edison | Mr Shaun Png<br>65080-666<br>[png\_jia\_shun@schools.gov.sg](mailto:png\_jia\_shun@schools.gov.sg) | Ms Nurbayah<br>65087-300 (Ext 651)<br>[nurbayah\_ismail@schools.gov.sg](mailto:nurbayah\_ismail@schools.gov.sg) |
-| 6 Frank | Mrs Michelle Wee<br>65080-667<br>[michelle\_tyoh\_whei\_theng@schools.gov.sg](mailto:michelle\_tyoh\_whei\_theng@schools.gov.sg) |Mr Hisham (HOD, PE &amp; CCA)<br>65087-309<br>[hisham\_b\_spono@schools.gov.sg](mailto:hisham\_b\_spono@schools.gov.sg) |
- 6 Galileo | Mr Guna<br>65080-668<br>[sargunan\_ilangovan@schools.gov.sg](mailto:sargunan\_ilangovan@schools.gov.sg) |Mdm Hwee Yeng<br>65087-268<br>[lim\_hwee\_yeng@schools.gov.sg](mailto:lim\_hwee\_yeng@schools.gov.sg)
-| | | |
+| 
+
+Will be updated soon....
 
 ### Subject Teachers
 
 | Subject | Teacher |
 |---|---|
-| Art |Mrs Chew Yixin<br>65080-662<br>[tan\_yixin@schools.gov.sg](mailto:tan\_yixin@schools.gov.sg) |
-Art |Mdm Karmila<br>65089-458<br>[nor\_karmila\_hamzah@schools.gov.sg](mailto:nor\_karmila\_hamzah@schools.gov.sg)
-Art |Mdm Adzilah<br>65080-663<br>[noor\_adzilah\_tahir@schools.gov.sg](mailto:noor\_adzilah\_tahir@schools.gov.sg)
-|
-| English | Ms Hidayah<br>65089-469<br>[nur\_hidayah\_mohshin@schools.gov.sg](mailto:nur\_hidayah\_mohshin@schools.gov.sg) |
-| English | Mdm Leong Fong Fong<br>65080-655<br>[leong\_fong\_fong@schools.gov.sg](mailto:leong\_fong\_fong@schools.gov.sg) |
-| English | Mrs Irene Ang (YH, Upper Primary)<br>65087-312<br>[irene\_chia@schools.gov.sg](mailto:irene\_chia@schools.gov.sg) |
-| English | Mr Kelvin Chia (ST, Science)<br>65080-665<br>[chia\_peng\_lin\_kelvin@schools.gov.sg](mailto:chia\_peng\_lin\_kelvin@schools.gov.sg) |
-| English | Mr Isa<br>65067-346<br>[mohamed\_isa\_b\_osman@schools.gov.sg](mailto:mohamed\_isa\_b\_osman@schools.gov.sg) |
-| English | Mrs Michelle Wee<br>65080-667<br>[michelle\_tyoh\_whei\_theng@schools.gov.sg](mailto:michelle\_tyoh\_whei\_theng@schools.gov.sg) |
-| English | Ms Nurul Ain (ST, EL)<br>65087-328<br>[nurul\_ain\_mohamad\_ibrahim@schools.gov.sg](mailto:nurul\_ain\_mohamad\_ibrahim@schools.gov.sg) |
-| English | Mdm Subaitha<br>65089-467<br>[subaitha\_bee\_sahul\_hameed@moe.edu.sg](mailto:subaitha\_bee\_sahul\_hameed@moe.edu.sg) |
-|
-| Mathematics | Ms Audrey Loke (HOD, Math)<br>65083-170<br>[loke\_ai\_guat\_audrey@schools.gov.sg](mailto:loke\_ai\_guat\_audrey@schools.gov.sg) |
-| Mathematics |Mdm Leong Fong Fong<br>65080-655<br>[leong\_fong\_fong@schools.gov.sg](mailto:leong\_fong\_fong@schools.gov.sg) |
-Mathematics |Mrs Irene Ang (YH, Upper Primary)<br>65087-312<br>[irene\_chia@schools.gov.sg](mailto:irene\_chia@schools.gov.sg) |
-Mathematics |Mdm Josephine Kee<br>65067-342<br>[kee\_wan\_cheng@schools.gov.sg](mailto:kee\_wan\_cheng@schools.gov.sg) |
-Mathematics |Mr Shaun Png<br>65080-666<br>[png\_jia\_shun@schools.gov.sg](mailto:png\_jia\_shun@schools.gov.sg) |
-Mathematics |Mrs Jodie Siow<br>65087-316<br>[yeo\_mui\_hong@schools.gov.sg](mailto:yeo\_mui\_hong@schools.gov.sg) |
-Mathematics |Mr Guna<br>65080-668<br>[sargunan\_ilangovan@schools.gov.sg](mailto:sargunan\_ilangovan@schools.gov.sg) |
-Mathematics |Mdm Radiah<br>65067-341<br>[radiah\_rahmat@schools.gov.sg](mailto:radiah\_rahmat@schools.gov.sg) |
-Mathematics |Mrs Jaslin Kwa<br>65089-455<br>[jaslin\_ku\_siew\_chen@moe.edu.sg](mailto:jaslin\_ku\_siew\_chen@moe.edu.sg)
-|
-Science |Mr Gerald Wong (HOD, Science)<br>65087-313<br>[gerald\_wong\_yew\_meng@schools.gov.sg](mailto:gerald\_wong\_yew\_meng@schools.gov.sg) |
-Science |Mr Senthil [Zack] (SH, Student Well-Being)<br>65080-664<br>[subramaniyan\_senthil@schools.gov.sg](mailto:subramaniyan\_senthil@schools.gov.sg) |
-Science |Mdm Esther Tay (LH, Science)<br>65087-330<br>[tay\_wei\_jing@schools.gov.sg](mailto:tay\_wei\_jing@schools.gov.sg) 
-Science |Mr Shaun Png<br>65080-666<br>[png\_jia\_shun@schools.gov.sg](mailto:png\_jia\_shun@schools.gov.sg) |
-Science| Mr&nbsp;Kelvin Chia (ST, Science)<br>65080-665<br>[chia\_peng\_lin\_kelvin@schools.gov.sg](mailto:chia\_peng\_lin\_kelvin@schools.gov.sg) |
-Science |Mr Guna<br>65080-668<br>[sargunan\_ilangovan@schools.gov.sg](mailto:sargunan\_ilangovan@schools.gov.sg) |
-Science |Mrs Michelle Wee<br>65080-667<br>[michelle\_tyoh\_whei\_theng@schools.gov.sg](mailto:michelle\_tyoh\_whei\_theng@schools.gov.sg) |
-|
-| Chinese Language | Ms Loo Yee<br>65087-271<br>[lee_loo_yee@schools.gov.sg](mailto:lee_loo_yee@schools.gov.sg) |
-Chinese Language | Mdm Heng Wei Shan<br>65089-450<br>[heng\_wei\_shan\_a@schools.gov.sg](mailto:heng\_wei\_shan\_a@schools.gov.sg) 
-Chinese Language |Mdm Hwee Yeng<br>65087-268<br>[lim\_hwee\_yeng@schools.gov.sg](mailto:lim\_hwee\_yeng@schools.gov.sg) 
-Chinese Language | Mrs Lim Bee Li<br>65087-266<br>[tay\_bee\_li@schools.gov.sg](mailto:tay\_bee\_li@schools.gov.sg) 
-Chinese Language | Mrs Faye Loh (LH, CL)<br>65087-264<br>[quah\_pei\_jun@schools.gov.sg](mailto:quah\_pei\_jun@schools.gov.sg) 
-Chinese Language | Mr Warren Thin (HOD, ICT)<br>65087-268<br>[thin\_dongqi@schools.gov.sg](mailto:thin\_dongqi@schools.gov.sg) 
-Chinese Language | Mr Zhou Wencong (HOD, SM)<br>65087-322<br>[zhou\_wencong@schools.gov.sg](mailto:zhou\_wencong@schools.gov.sg) 
-|
-| Malay Language |Mdm Elyani (ST, Malay Language)<br>65080-654<br>[elyani\_mohamed@schools.gov.sg](mailto:elyani\_mohamed@schools.gov.sg) |
-| Malay Language  |Mdm Nabilah<br>65087-319<br>[nabilah\_abdul\_rahman@schools.gov.sg](mailto:nabilah\_abdul\_rahman@schools.gov.sg) |
-| Malay Language  |Ms Nurbayah<br>65087-300 (Ext 651)<br>[nurbayah\_ismail@schools.gov.sg](mailto:nurbayah\_ismail@schools.gov.sg) |
-|
-| Music | Ms Rebecca Lau (ST, Music)<br>65089-456<br>[rebecca\_lau\_yuen\_sun@schools.gov.sg](mailto:rebecca\_lau\_yuen\_sun@schools.gov.sg) |
-| Music |Mr Bryon Luo<br>65089-457<br>[luo\_youde\_bryon@schools.gov.sg](mailto:luo\_youde\_bryon@schools.gov.sg) |
-|
-| Physical Education and Health Education | Mr Hisham (HOD, PE &amp; CCA)<br>65087-309<br>[hisham\_b\_spono@schools.gov.sg](mailto:hisham\_b\_spono@schools.gov.sg) |
-| Physical Education and Health Education | Mr Rafiei<br>65087-275<br>[mohamad\_rafiei\_sakeyam@schools.gov.sg](mailto:mohamad\_rafiei\_sakeyam@schools.gov.sg) |
-| Physical Education and Health Education | Mr Nadeem<br>65087-276<br>[mohamed_nadeem@schools.gov.sg](mailto:mohamed_nadeem@schools.gov.sg) |
+
+Will be updated soon....


### PR DESCRIPTION
I will delete 2024's deployments and amend with a "Will be updated soon" caption for the time being while i work to update the respective level's deployments with seperate pull requests.