### PR TITLE
Removal of "SLS Troubleshooting" Tab from website

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -42,8 +42,6 @@ links:
         url: /for-parents/home-school-partnership/
       - title: Parent Support Group
         url: /for-parents/Parent-Support-Group/
-      - title: SLS Troubleshooting
-        url: https://www.learning.moe.edu.sg/sls/user-guide/vle/logintroubleshooting/index.html
       - title: Useful Information
         url: /for-parents/Useful-Links/
   - title: Contact Us


### PR DESCRIPTION
I have removed this tab since SLS has removed this URL from their website and it's no longer a valid URL.